### PR TITLE
Changed MarkdownSharp namespace

### DIFF
--- a/src/ServiceStack/WebHost.Endpoints/EndpointHostConfig.cs
+++ b/src/ServiceStack/WebHost.Endpoints/EndpointHostConfig.cs
@@ -432,7 +432,7 @@ namespace ServiceStack.WebHost.Endpoints
         public bool ReturnsInnerException { get; set; }
         public bool WriteErrorsToResponse { get; set; }
 
-        public MarkdownOptions MarkdownOptions { get; set; }
+        internal MarkdownOptions MarkdownOptions { get; set; }
         public Type MarkdownBaseType { get; set; }
         public Dictionary<string, Type> MarkdownGlobalHelpers { get; set; }
         public Dictionary<string, string> HtmlReplaceTokens { get; set; }

--- a/src/ServiceStack/WebHost.Endpoints/EndpointHostConfig.cs
+++ b/src/ServiceStack/WebHost.Endpoints/EndpointHostConfig.cs
@@ -9,7 +9,7 @@ using System.Runtime.Serialization;
 using System.Web;
 using System.Web.Configuration;
 using System.Xml.Linq;
-using MarkdownSharp;
+using ServiceStack.MarkdownSharp;
 using ServiceStack.Common.ServiceModel;
 using ServiceStack.Common.Utils;
 using ServiceStack.Common.Web;

--- a/src/ServiceStack/WebHost.Endpoints/Support/Markdown/Markdown.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/Markdown/Markdown.cs
@@ -89,7 +89,7 @@ using System.Configuration;
 using System.Text;
 using System.Text.RegularExpressions;
 
-namespace MarkdownSharp
+namespace ServiceStack.MarkdownSharp
 {
 
     public class MarkdownOptions

--- a/src/ServiceStack/WebHost.Endpoints/Support/Markdown/Markdown.cs
+++ b/src/ServiceStack/WebHost.Endpoints/Support/Markdown/Markdown.cs
@@ -92,7 +92,7 @@ using System.Text.RegularExpressions;
 namespace ServiceStack.MarkdownSharp
 {
 
-    public class MarkdownOptions
+    internal class MarkdownOptions
     {
         /// <summary>
         /// when true, (most) bare plain URLs are auto-hyperlinked  
@@ -131,7 +131,7 @@ namespace ServiceStack.MarkdownSharp
     /// Markdown allows you to write using an easy-to-read, easy-to-write plain text format, 
     /// then convert it to structurally valid XHTML (or HTML).
     /// </summary>
-    public class Markdown
+    internal class Markdown
     {
         //Mono's RegEx is very limited and can't support avg-sized Markdown documents
         public static bool UseMarkdownDeep = ServiceStack.Text.Env.IsMono || true; 


### PR DESCRIPTION
This was causing namespace collisions with the real MarkdownSharp library.
