### PR TITLE
New exception model

### DIFF
--- a/src/ServiceStack/ServiceHost/DtoUtils.cs
+++ b/src/ServiceStack/ServiceHost/DtoUtils.cs
@@ -159,7 +159,7 @@ namespace ServiceStack.ServiceHost
 
             var responseStatus = ex.ToResponseStatus();
 
-            if (EndpointHost.DebugMode)
+            if (EndpointHost.ReportExceptionStackTraces)
             {
                 // View stack trace in tests and on the client
                 responseStatus.StackTrace = GetRequestErrorBody(request) + "\n" + ex;

--- a/src/ServiceStack/ServiceHost/DtoUtils.cs
+++ b/src/ServiceStack/ServiceHost/DtoUtils.cs
@@ -159,7 +159,7 @@ namespace ServiceStack.ServiceHost
 
             var responseStatus = ex.ToResponseStatus();
 
-            if (EndpointHost.ReportExceptionStackTraces)
+            if (EndpointHost.DebugMode || EndpointHost.ReportExceptionStackTraces)
             {
                 // View stack trace in tests and on the client
                 const int maxStackTraceLength = 10000;

--- a/src/ServiceStack/ServiceHost/DtoUtils.cs
+++ b/src/ServiceStack/ServiceHost/DtoUtils.cs
@@ -162,7 +162,17 @@ namespace ServiceStack.ServiceHost
             if (EndpointHost.ReportExceptionStackTraces)
             {
                 // View stack trace in tests and on the client
-                responseStatus.StackTrace = GetRequestErrorBody(request) + "\n" + ex;
+                const int maxStackTraceLength = 10000;
+                string extendedStackTrace = GetRequestErrorBody(request) + "\n" + ex;
+                if (extendedStackTrace.Length < maxStackTraceLength)
+                {
+                    responseStatus.StackTrace = extendedStackTrace;
+                }
+                else
+                {
+                    // Reduce harm in case of overwhelming stack trace size.
+                    responseStatus.StackTrace = extendedStackTrace.Substring(0, maxStackTraceLength - 3) + "...";
+                }
             }
 
             Log.Error("ServiceBase<TRequest>::Service Exception", ex);

--- a/src/ServiceStack/WebHost.Endpoints/EndpointHost.cs
+++ b/src/ServiceStack/WebHost.Endpoints/EndpointHost.cs
@@ -310,6 +310,14 @@ namespace ServiceStack.WebHost.Endpoints
             get { return Config != null && Config.DebugMode; }
         }
 
+        public static bool ReportExceptionStackTraces
+        {
+            get
+            {
+                return Config != null && Config.ReportExceptionStackTraces;
+            }
+        }
+
         public static ServiceMetadata Metadata { get { return Config.Metadata; } }
 
         /// <summary>

--- a/src/ServiceStack/WebHost.Endpoints/EndpointHostConfig.cs
+++ b/src/ServiceStack/WebHost.Endpoints/EndpointHostConfig.cs
@@ -70,6 +70,7 @@ namespace ServiceStack.WebHost.Endpoints
                         AllowNonHttpOnlyCookies = false,
                         UseHttpsLinks = false,
                         DebugMode = false,
+                        ReportExceptionStackTraces = true,
                         DefaultDocuments = new List<string> {
 							"default.htm",
 							"default.html",
@@ -167,6 +168,7 @@ namespace ServiceStack.WebHost.Endpoints
             this.AllowJsonpRequests = instance.AllowJsonpRequests;
             this.AllowRouteContentTypeExtensions = instance.AllowRouteContentTypeExtensions;
             this.DebugMode = instance.DebugMode;
+            this.ReportExceptionStackTraces = instance.ReportExceptionStackTraces;
             this.DefaultDocuments = instance.DefaultDocuments;
             this.GlobalResponseHeaders = instance.GlobalResponseHeaders;
             this.IgnoreFormatsInMetadata = instance.IgnoreFormatsInMetadata;
@@ -406,6 +408,7 @@ namespace ServiceStack.WebHost.Endpoints
         public bool AllowJsonpRequests { get; set; }
         public bool AllowRouteContentTypeExtensions { get; set; }
         public bool DebugMode { get; set; }
+        public bool ReportExceptionStackTraces { get; set; }
         public bool DebugOnlyReturnRequestInfo { get; set; }
         public string DebugAspNetHostEnvironment { get; set; }
         public string DebugHttpListenerHostEnvironment { get; set; }

--- a/src/ServiceStack/WebHost.Endpoints/EndpointHostConfig.cs
+++ b/src/ServiceStack/WebHost.Endpoints/EndpointHostConfig.cs
@@ -70,7 +70,7 @@ namespace ServiceStack.WebHost.Endpoints
                         AllowNonHttpOnlyCookies = false,
                         UseHttpsLinks = false,
                         DebugMode = false,
-                        ReportExceptionStackTraces = true,
+                        ReportExceptionStackTraces = false,
                         DefaultDocuments = new List<string> {
 							"default.htm",
 							"default.html",


### PR DESCRIPTION
@ZocDoc/coreinfrastructure 
This PR changes a configuration feature, that controls the inclusion of stack traces with exceptions.
A new flag `ReportExceptionStackTraces` narrowly controls only this behavior.
It defaults to false and may be set true by a specific EndpointHost.
Very large stack traces (length > 10k) are truncated to prevent harm escalation.
