### PR TITLE
hoisted the ".Result" call for async operations to be further down the stack

### DIFF
--- a/src/ServiceStack/ServiceHost/ServiceRunner.cs
+++ b/src/ServiceStack/ServiceHost/ServiceRunner.cs
@@ -118,6 +118,16 @@ namespace ServiceStack.ServiceHost
 
                 var response = AfterEachRequest(requestContext, request, ServiceAction(instance, request));
 
+                // This is a temporary solution that minimally supports async operations. Services may implement
+                // async endpoints, and the eventual responseDto will contain the correct response, but true async behavior
+                // is not implemented at this time. The Task<TResponse> returned by the operation will block in ".Result".
+                // TODO: Implement a real async stack, all the way from HttpAsyncHandler down to this point.
+                var responseAsAsync = response as Task<object>;
+                if (responseAsAsync != null)
+                {
+                    response = responseAsAsync.Result;
+                }
+
                 if (ResponseFilters != null)
                 {
                     foreach (var responseFilter in ResponseFilters)
@@ -187,23 +197,10 @@ namespace ServiceStack.ServiceHost
         //signature matches ServiceExecFn
         public object Process(IRequestContext requestContext, object instance, object request)
         {
-            var operationReturn = requestContext != null && requestContext.EndpointAttributes.Has(EndpointAttributes.OneWay) 
+            return requestContext != null && requestContext.EndpointAttributes.Has(EndpointAttributes.OneWay) 
                 ? ExecuteOneWay(requestContext, instance, (TRequest)request) 
                 : Execute(requestContext, instance, (TRequest)request);
 
-            // This is a temporary solution that minimally supports async operations. Services may implement
-            // async endpoints, and the eventual responseDto will contain the correct response, but true async behavior
-            // is not implemented at this time. The Task<TResponse> returned by the operation will block in ".Result".
-            // TODO: Implement a real async stack, all the way from HttpAsyncHandler down to this point.
-            var operationReturnAsAsync = operationReturn as Task<object>;
-            if (operationReturnAsAsync == null)
-            {
-                return operationReturn;
-            }
-            else
-            {
-                return operationReturnAsAsync.Result;
-            }
         }
     }
 }


### PR DESCRIPTION
The ".Result" for async operations needed to be further down the stack so that it was within the lowest possible try-catch block.
@ZocDoc/coreinfrastructure 
I'd like to merge this by end of day. If you want more time than that to review, just let me know.
