### PR TITLE
Dependency injection registration

### DIFF
--- a/src/ServiceStack.ServiceInterface/Validation/ValidationFeature.cs
+++ b/src/ServiceStack.ServiceInterface/Validation/ValidationFeature.cs
@@ -79,7 +79,7 @@ namespace ServiceStack.ServiceInterface.Validation
             var dtoType = baseType.GetGenericArguments()[0];
             var validatorType = typeof(IValidator<>).MakeGenericType(dtoType);
 
-            dependencyService.RegisterAutoWiredType(validator, validatorType);
+            dependencyService.RegisterAsType(validator, validatorType, DependencyService.Sharing.None, false);
         }
     }
 }

--- a/src/ServiceStack/DependencyInjection/DependencyService.cs
+++ b/src/ServiceStack/DependencyInjection/DependencyService.cs
@@ -44,27 +44,33 @@ namespace ServiceStack.DependencyInjection
             if (implementingType.IsGenericType)
             {
                 var registration = _containerBuilder.RegisterGeneric(implementingType);
+
                 if (registerAsImplementedInterfaces)
                 {
                     registration = registration.AsImplementedInterfaces();
                 }
+
                 if (includeNonPublicConstructors)
                 {
                     registration = registration.FindConstructorsWith(type => type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
                 }
+
                 registration = SetRegistrationLifetime(registration, sharing);
             }
             else
             {
                 var registration = _containerBuilder.RegisterType(implementingType).AsSelf();
+
                 if (registerAsImplementedInterfaces)
                 {
                     registration = registration.AsImplementedInterfaces();
                 }
+
                 if (includeNonPublicConstructors)
                 {
                     registration = registration.FindConstructorsWith(type => type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
                 }
+
                 registration = SetRegistrationLifetime(registration, sharing);
             }
         }

--- a/src/ServiceStack/DependencyInjection/DependencyService.cs
+++ b/src/ServiceStack/DependencyInjection/DependencyService.cs
@@ -85,11 +85,10 @@ namespace ServiceStack.DependencyInjection
                     registration.InstancePerDependency();
                     break;
                 case Sharing.PerRequest:
-                    registration.InstancePerMatchingLifetimeScope("httpRequest");
+                    registration.InstancePerLifetimeScope();
                     break;
                 case Sharing.Singleton:
-                    registration.RegistrationData.Sharing = InstanceSharing.Shared;
-                    registration.RegistrationData.Lifetime = new RootScopeLifetime();
+                    registration.SingleInstance();
                     break;
             }
         }

--- a/src/ServiceStack/DependencyInjection/DependencyService.cs
+++ b/src/ServiceStack/DependencyInjection/DependencyService.cs
@@ -38,7 +38,7 @@ namespace ServiceStack.DependencyInjection
             _containerBuilder = new ContainerBuilder();
         }
 
-        public void RegisterType(Type implementingType, Sharing sharing, bool registerAsImplementedInterfaces, bool includeNonPublicConstructors)
+        public void Register(Type implementingType, Sharing sharing, bool registerAsImplementedInterfaces, bool includeNonPublicConstructors)
         {
             if (implementingType.IsGenericType)
             {
@@ -66,6 +66,16 @@ namespace ServiceStack.DependencyInjection
                 }
                 registration = SetRegistrationLifetime(registration, sharing);
             }
+        }
+
+        public void RegisterAsType(Type implementingType, Type registrationType, Sharing sharing, bool includeNonPublicConstructors)
+        {
+            var registration = _containerBuilder.RegisterType(implementingType).As(registrationType);
+            if (includeNonPublicConstructors)
+            {
+                registration = registration.FindConstructorsWith(type => type.GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic));
+            }
+            registration = SetRegistrationLifetime(registration, sharing);
         }
 
         public void RegisterSingletonInstance(object classInstance, bool registerAsImplementedInterfaces)
@@ -134,21 +144,29 @@ namespace ServiceStack.DependencyInjection
 
         // These methods are obsolete. They are called in code branches that are believed to be dead.
         // If any of that code ever becomes active, we need to know that, so the code 'throws' here.
-        public void AutoWire(object instance) // ServiceRunner, EndPointHost
+        [Obsolete]
+        internal void AutoWire(object instance) // ServiceRunner, EndPointHost
             { throw new NotImplementedException("AutoWire(object)"); }
-        public void RegisterAutoWiredType(Type type) // ServiceManager
+        [Obsolete]
+        internal void RegisterAutoWiredType(Type type) // ServiceManager
             { throw new NotImplementedException("AutoWiredType(Type)"); }
-        public void RegisterAutoWiredAs<T, TAs>() // AppHostBase, HttpListenerBase
+        [Obsolete]
+        internal void RegisterAutoWiredAs<T, TAs>() // AppHostBase, HttpListenerBase
             { throw new NotImplementedException("RegisterAutoWiredAs<T, TAs>()"); }
-        public void RegisterAutoWired<T>() // ServiceManager
+        [Obsolete]
+        internal void RegisterAutoWired<T>() // ServiceManager
             { throw new NotImplementedException("RegisterAutoWired<T>()"); }
-        public void Register<T>(T instance) // AppHostBase, HttpListenerBase, EndpointHost
+        [Obsolete]
+        internal void Register<T>(T instance) // AppHostBase, HttpListenerBase, EndpointHost
             { throw new NotImplementedException("Register<T>(instance)"); }
-        public T Resolve<T>(ILifetimeScope lifetimeScope = null) // AppHostBase, HttpListenerBase
+        [Obsolete]
+        internal T Resolve<T>(ILifetimeScope lifetimeScope = null) // AppHostBase, HttpListenerBase
             { throw new NotImplementedException("Resolve<T>(ILifetimeScope)"); }
-        public void Register(Func<Container, object> f)// ValidationFeature [ServiceStack.erviceInterface], EndpointHost
+        [Obsolete]
+        internal void Register(Func<Container, object> f)// ValidationFeature [ServiceStack.erviceInterface], EndpointHost
             { throw new NotImplementedException("Register(Func<Container, object>)"); }
-        public void RegisterAutoWiredType(Type serviceType, Type inFunqAsType) // ValidationFeature [ServiceInterface]
+        [Obsolete]
+        internal void RegisterAutoWiredType(Type serviceType, Type inFunqAsType) // ValidationFeature [ServiceInterface]
             { throw new NotImplementedException(""); }
     }
 }

--- a/src/ServiceStack/ServiceHost/ServiceManager.cs
+++ b/src/ServiceStack/ServiceHost/ServiceManager.cs
@@ -84,7 +84,7 @@ namespace ServiceStack.ServiceHost
 
             foreach (var type in this.Metadata.ServiceTypes)
 		    {
-		        this.DependencyService.RegisterTypeAsItself(type);
+                this.DependencyService.RegisterType(type, DependencyService.Sharing.None, registerAsImplementedInterfaces: false, includeNonPublicConstructors: false);
 		    }
 
 		    return this;
@@ -144,7 +144,7 @@ namespace ServiceStack.ServiceHost
         {
             var serviceType = serviceImplementation.GetType();
 
-            DependencyService.RegisterSingletonInstance(serviceImplementation, serviceType);
+            DependencyService.RegisterSingletonInstance(serviceImplementation, registerAsImplementedInterfaces: false);
 
             this.ServiceController.RegisterNService(serviceType, DependencyService);
 

--- a/src/ServiceStack/ServiceHost/ServiceManager.cs
+++ b/src/ServiceStack/ServiceHost/ServiceManager.cs
@@ -84,7 +84,7 @@ namespace ServiceStack.ServiceHost
 
             foreach (var type in this.Metadata.ServiceTypes)
 		    {
-                this.DependencyService.RegisterType(type, DependencyService.Sharing.None, registerAsImplementedInterfaces: false, includeNonPublicConstructors: false);
+                this.DependencyService.Register(type, DependencyService.Sharing.None, registerAsImplementedInterfaces: false, includeNonPublicConstructors: false);
 		    }
 
 		    return this;

--- a/src/ServiceStack/ServiceHost/ServiceManager.cs
+++ b/src/ServiceStack/ServiceHost/ServiceManager.cs
@@ -83,11 +83,11 @@ namespace ServiceStack.ServiceHost
             this.ServiceController.Register(DependencyService);
 
             foreach (var type in this.Metadata.ServiceTypes)
-		    {
+            {
                 this.DependencyService.Register(type, DependencyService.Sharing.None, registerAsImplementedInterfaces: false, includeNonPublicConstructors: false);
-		    }
+            }
 
-		    return this;
+            return this;
 		}
 
 		public void RegisterService<T>()

--- a/src/ServiceStack/ServiceHost/ServiceManager.cs
+++ b/src/ServiceStack/ServiceHost/ServiceManager.cs
@@ -88,7 +88,7 @@ namespace ServiceStack.ServiceHost
             }
 
             return this;
-		}
+        }
 
 		public void RegisterService<T>()
 		{


### PR DESCRIPTION
There exist subtle differences between how this ServiceStack fork handles registering services for dependency injection and how the other ZocDoc applications register them.  The changes in this PR reconcile those differences.

The changes to `DependencyService` create a new `Register()` method as the primary way of registering dependencies.  There also exists the `RegisterAsType()` and `RegisterSingletonInstance()` methods for special cases.  This PR also hides methods that are required by the ServiceStack internals, but aren't implemented.

@ZocDoc/coreinfrastructure 
