### PR TITLE
use Expect100Continue=true for all ServiceStack requests

### DIFF
--- a/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
@@ -628,6 +628,7 @@ namespace ServiceStack.ServiceClient.Web
             {
                 client.Accept = Accept;
                 client.Method = httpMethod;
+                client.ServicePoint.Expect100Continue = true;
                 client.Headers.Add(Headers);
 
                 if (Proxy != null) client.Proxy = Proxy;

--- a/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
+++ b/src/ServiceStack.Common/ServiceClient.Web/ServiceClientBase.cs
@@ -118,6 +118,7 @@ namespace ServiceStack.ServiceClient.Web
             };
             this.CookieContainer = new CookieContainer();
             this.StoreCookies = true; //leave
+            this.Expect100ContinueOverride = null;
 #if NETFX_CORE || WINDOWS_PHONE || SILVERLIGHT
             this.Headers = new Dictionary<string, string>();
 #else
@@ -320,6 +321,12 @@ namespace ServiceStack.ServiceClient.Web
             get { return storeCookies; }
             set { asyncClient.StoreCookies = storeCookies = value; }
         }
+
+        /// <summary>
+        /// Optionally specifies a value to use for HttpWebRequest.Expect100Continue, overriding the default.
+        /// </summary>
+        public bool? Expect100ContinueOverride { get; set; }
+
 
         private CookieContainer _cookieContainer;
         public CookieContainer CookieContainer
@@ -628,7 +635,10 @@ namespace ServiceStack.ServiceClient.Web
             {
                 client.Accept = Accept;
                 client.Method = httpMethod;
-                client.ServicePoint.Expect100Continue = true;
+                if (Expect100ContinueOverride.HasValue)
+                {
+                    client.ServicePoint.Expect100Continue = Expect100ContinueOverride.Value;
+                }
                 client.Headers.Add(Headers);
 
                 if (Proxy != null) client.Proxy = Proxy;


### PR DESCRIPTION
CC: @ZocDoc/coreinfrastructure 

@kyle-fritz-zocdoc 
This is the fix I was describing on Monday.
I list 7 issues below, and prioritize them as "blocking" and "non-blocking". Please review this prioritization.

Blocking concerns:
1. Does this change work, i.e. sets Expect100Continue, and decreases prod latency to be << 10 ms?
2. Does this change affect the other HttpRequests made in the Monolith?
3. Does this change hurt MSA->MSA request performance?

Non-blocking concerns:
1. Could the idle-timeout clear the value of servicePoint.Expect100Continue, before the request is actually sent out?
2. What is the actual mechanism that is slowing down these Monolith -> MSA requests?
3. Why is Expect100Continue 'false' in prod and 'true' everywhere else?
4. Does prod actually depend on a global 'Expect100Continue == false' 
