### PR TITLE
A dispose leak was happening in service stack because sometimes these…

### DIFF
--- a/src/ServiceStack.Common/HostContext.cs
+++ b/src/ServiceStack.Common/HostContext.cs
@@ -66,20 +66,18 @@ namespace ServiceStack.Common
     {
         public const string HashId = "__disposables";
 
-        List<WeakReference> disposables = new List<WeakReference>();
+        List<IDisposable> disposables = new List<IDisposable>();
 
         public void Add(IDisposable instance)
         {
-            disposables.Add(new WeakReference(instance));
+            disposables.Add(instance);
         }
 
         public void Dispose()
         {
-            foreach (var wr in disposables)
+            foreach (var d in disposables)
             {
-                var disposable = (IDisposable)wr.Target;
-                if (wr.IsAlive)
-                    disposable.Dispose();
+                d.Dispose();
             }
         }
     }


### PR DESCRIPTION
… weak references are being garbage collected before dispose is called on them.
